### PR TITLE
Update stable to Alpine 3.21

### DIFF
--- a/stable/alpine-slim/Dockerfile
+++ b/stable/alpine-slim/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.20
+FROM alpine:3.21
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/update.sh
+++ b/update.sh
@@ -56,7 +56,7 @@ declare -A debian=(
 
 declare -A alpine=(
     [mainline]='3.21'
-    [stable]='3.20'
+    [stable]='3.21'
 )
 
 # When we bump njs version in a stable release we don't move the tag in the


### PR DESCRIPTION
### Proposed changes

This is a follow-up to #948, given that in my eyes it seems most likely a new mainline release will precede a new stable release.

Updates the stable image to use Alpine 3.21 as default version. See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.21.0.

Note: given that this requires built binaries for the new Alpine version and won't take any effect until an actual new release of `nginx` itself, this PR is intentionally marked as draft, so it can function both as a heads-up about the new release and a place that allows for subscription to any potential updates. It can then be merged later at any convenient time when everything is ready. However, if it is still preferable to close this in the meantime, feel free to do so.

Modelled after #895.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
