### PR TITLE
Change the org following the repo transfer to nginx namespace.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Describe the use case and detail of the change. If this PR addresses an issue on
 ### Checklist
 
 Before creating a PR, run through this checklist and mark each as complete:
-- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
+- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginx/docker-nginx/blob/master/CONTRIBUTING.md) document
 - [ ] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
 - [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
 - [ ] If applicable, I have checked that any relevant tests pass after adding my changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The following is a set of guidelines for contributing to the Docker NGINX image.
 
 [Code Guidelines](#code-guidelines)
 
-[Code of Conduct](https://github.com/nginxinc/docker-nginx/blob/master/CODE_OF_CONDUCT.md)
+[Code of Conduct](https://github.com/nginx/docker-nginx/blob/master/CODE_OF_CONDUCT.md)
 
 ## Getting Started
 
@@ -20,18 +20,18 @@ Follow our [how to use this image guide](https://hub.docker.com/_/nginx/) to get
 
 ### Report a Bug
 
-To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](https://github.com/nginxinc/docker-nginx/blob/master/SECURITY.md).**
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](https://github.com/nginx/docker-nginx/blob/master/SECURITY.md).**
 
 ### Suggest a Feature or Enhancement
 
-To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](https://github.com/nginxinc/docker-nginx/blob/master/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
+To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](https://github.com/nginx/docker-nginx/blob/master/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
 
 ### Open a Pull Request
 
 - Fork the repo, create a branch, implement your changes, add any relevant tests, submit a PR when your changes are **tested** and ready for review.
-- Fill in [our pull request template](https://github.com/nginxinc/docker-nginx/blob/master/.github/pull_request_template.md).
+- Fill in [our pull request template](https://github.com/nginx/docker-nginx/blob/master/.github/pull_request_template.md).
 
-Note: if you'd like to implement a new feature, please consider creating a [feature request issue](https://github.com/nginxinc/docker-nginx/blob/master/.github/feature_request_template.md) first to start a discussion about the feature.
+Note: if you'd like to implement a new feature, please consider creating a [feature request issue](https://github.com/nginx/docker-nginx/blob/master/.github/feature_request_template.md) first to start a discussion about the feature.
 
 ## Code Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/docker-nginx/blob/master/SUPPORT.md)
+[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginx/docker-nginx/blob/master/SUPPORT.md)
 
 # About this Repo
 
-## Maintained by: [the NGINX Docker Maintainers](https://github.com/nginxinc/docker-nginx)
+## Maintained by: [the NGINX Docker Maintainers](https://github.com/nginx/docker-nginx)
 
 This is the Git repo of the [Docker "Official Image"](https://github.com/docker-library/official-images#what-are-official-images) for [`nginx`](https://hub.docker.com/_/nginx/). See [the Docker Hub page](https://hub.docker.com/_/nginx/) for the full readme on how to use this Docker image and for information regarding contributing and issues.
 
@@ -19,17 +19,17 @@ For outstanding `nginx` image PRs, check [PRs with the "library/nginx" label on 
 
 ## Contributing
 
-Please see the [contributing guide](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](https://github.com/nginx/docker-nginx/blob/master/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
 
 ## License
 
-[BSD 2-Clause](https://github.com/nginxinc/docker-nginx/blob/master/LICENSE)
+[BSD 2-Clause](https://github.com/nginx/docker-nginx/blob/master/LICENSE)
 
 &copy; [F5, Inc.](https://www.f5.com/) 2023
 
 ---
 
-- [![build status badge](https://img.shields.io/github/actions/workflow/status/nginxinc/docker-nginx/ci.yml?branch=master&label=GitHub%20CI)](https://github.com/nginxinc/docker-nginx/actions?query=workflow%3A%22GitHub+CI%22+branch%3Amaster)
+- [![build status badge](https://img.shields.io/github/actions/workflow/status/nginx/docker-nginx/ci.yml?branch=master&label=GitHub%20CI)](https://github.com/nginx/docker-nginx/actions?query=workflow%3A%22GitHub+CI%22+branch%3Amaster)
 
 | Build | Status | Badges | (per-arch) |
 |:-:|:-:|:-:|:-:|

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,7 +30,7 @@ Want to get in touch with the NGINX development team directly? Try using the rel
 
 ## Contributing
 
-Please see the [contributing guide](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](https://github.com/nginx/docker-nginx/blob/master/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
 
 ## Commercial Support
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -36,10 +36,10 @@ dirCommit() {
 }
 
 cat <<-EOH
-# this file is generated via https://github.com/nginxinc/docker-nginx/blob/$(fileCommit "$self")/$self
+# this file is generated via https://github.com/nginx/docker-nginx/blob/$(fileCommit "$self")/$self
 
-Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
-GitRepo: https://github.com/nginxinc/docker-nginx.git
+Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
+GitRepo: https://github.com/nginx/docker-nginx.git
 EOH
 
 # prints "$2$1$3$1...$N"

--- a/modules/README.md
+++ b/modules/README.md
@@ -14,7 +14,7 @@ enabled by setting the environment variable `DOCKER_BUILDKIT` to `1`.
 
 If you can not or do not want to use BuildKit, you can use a previous version
 of these files, see for example
-https://github.com/nginxinc/docker-nginx/tree/4bf0763f4977fff7e9648add59e0540088f3ca9f/modules.
+https://github.com/nginx/docker-nginx/tree/4bf0763f4977fff7e9648add59e0540088f3ca9f/modules.
 
 ## Usage
 
@@ -115,7 +115,7 @@ cd myapp
 
 ```
 mkdir my-nginx
-curl -o my-nginx/Dockerfile https://raw.githubusercontent.com/nginxinc/docker-nginx/master/modules/Dockerfile
+curl -o my-nginx/Dockerfile https://raw.githubusercontent.com/nginx/docker-nginx/master/modules/Dockerfile
 ```
 
 3. Create a `docker-compose.yml` file:
@@ -157,7 +157,7 @@ cd myapp-cache
 
 ```
 mkdir my-nginx
-curl -o my-nginx/Dockerfile https://raw.githubusercontent.com/nginxinc/docker-nginx/master/modules/Dockerfile
+curl -o my-nginx/Dockerfile https://raw.githubusercontent.com/nginx/docker-nginx/master/modules/Dockerfile
 mkdir my-nginx/cachepurge
 echo "https://github.com/FRiCKLE/ngx_cache_purge/archive/2.3.tar.gz" > my-nginx/cachepurge/source
 ```


### PR DESCRIPTION
### Proposed changes

Change the mentions of nginxinc org everywhere following the repo transfer to nginx org.

