### PR TITLE
fix: Target correct branch within CLA workflow

### DIFF
--- a/.github/workflows/f5_cla.yml
+++ b/.github/workflows/f5_cla.yml
@@ -19,9 +19,6 @@ jobs:
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         with:
-          # Any pull request targeting the following branch will trigger a CLA check.
-          # NOTE: You might need to edit this value to 'main'.
-          branch: master
           # Path to the CLA document.
           path-to-document: https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md
           # Custom CLA messages.
@@ -31,6 +28,8 @@ jobs:
           # Remote repository storing CLA signatures.
           remote-organization-name: f5
           remote-repository-name: f5-cla-data
+          # Branch where CLA signatures are stored.
+          branch: main
           path-to-signatures: signatures/signatures.json
           # Comma separated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
           # NOTE: You will want to edit the usernames to suit your project needs.


### PR DESCRIPTION
### Proposed changes

The CLA implementation in #970 was targeting the wrong branch in the signature data store. This PR fixes the issue.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [ ] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
