### PR TITLE
Update mainline to Debian trixie

### DIFF
--- a/mainline/debian-otel/Dockerfile
+++ b/mainline/debian-otel/Dockerfile
@@ -21,7 +21,7 @@ RUN set -x; \
     && case "$dpkgArch" in \
         amd64|arm64) \
 # arches officialy built by upstream
-            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ trixie nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
         *) \

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x; \
     && case "$dpkgArch" in \
         amd64|arm64) \
 # arches officialy built by upstream
-            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ trixie nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
         *) \

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -3,15 +3,15 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.29.0
 ENV NJS_VERSION     0.9.0
-ENV NJS_RELEASE     1~bookworm
-ENV PKG_RELEASE     1~bookworm
-ENV DYNPKG_RELEASE  1~bookworm
+ENV NJS_RELEASE     1~trixie
+ENV PKG_RELEASE     1~trixie
+ENV DYNPKG_RELEASE  1~trixie
 
 RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants
@@ -48,7 +48,7 @@ RUN set -x \
     && case "$dpkgArch" in \
         amd64|arm64) \
 # arches officialy built by upstream
-            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ trixie nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
         *) \

--- a/update.sh
+++ b/update.sh
@@ -50,7 +50,7 @@ declare -A dynpkg=(
 )
 
 declare -A debian=(
-    [mainline]='bookworm'
+    [mainline]='trixie'
     [stable]='bookworm'
 )
 


### PR DESCRIPTION
### Proposed changes

Updates the mainline image to use Debian trixie as default version. See also https://www.debian.org/News/2025/20250809.

Note: given that this requires built binaries for the new Alpine version and won't take any effect until an actual new release of `nginx` itself, this PR is intentionally marked as draft, so it can function both as a heads-up about the new release (in anticipation of a new mainline release of 1.29.0 that will probably appear soon?) and a place that allows for subscription to any potential updates. It can then be merged later at any convenient time when everything is ready. However, if it is still preferable to close this in the meantime, feel free to do so.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
